### PR TITLE
Fix percent sprite drawing order

### DIFF
--- a/SRC
+++ b/SRC
@@ -109,8 +109,8 @@ void updateDisplay() {
   int percent = (pumpDuty * 100) / 255;
   percentSprite.fillSprite(TFT_BLACK);
   percentSprite.drawNumber(percent, 0, 0);
-  percentSprite.pushSprite(140, VALUE_Y - 25);
   percentSprite.drawString("%", 55, 0);
+  percentSprite.pushSprite(140, VALUE_Y - 25);
   
   // 3. Actualizar barra de progreso parcialmente
   int newWidth = map(pumpDuty, 0, 255, 0, 200);


### PR DESCRIPTION
## Summary
- adjust order of operations in `updateDisplay()` so the `%` is drawn before pushing the sprite

## Testing
- `g++ -fsyntax-only -x c++ SRC` *(fails: `Arduino.h` missing)*

------
https://chatgpt.com/codex/tasks/task_e_68712d782ef48326af98bf807bb074e5