### PR TITLE
Fix initial pumpDuty tracking

### DIFF
--- a/SRC
+++ b/SRC
@@ -13,7 +13,7 @@ const int pwmChannel = 0;
 
 // Parámetros del sistema
 int pumpDuty = 0;
-int lastPumpDuty = -1;
+int lastPumpDuty = pumpDuty;
 const int minDuty = 30;
 const int maxDuty = 220;
 const int dutyStep = 5;


### PR DESCRIPTION
## Summary
- initialize `lastPumpDuty` with the current `pumpDuty` value

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68712d83e1b08326ad86ea9adf5c2595